### PR TITLE
fix logic for dealTier keys in adpod

### DIFF
--- a/modules/appnexusBidAdapter.js
+++ b/modules/appnexusBidAdapter.js
@@ -664,7 +664,7 @@ function bidToTag(bid) {
   } else {
     tag.hb_source = 1;
   }
-  
+
   if (bid.mediaType === VIDEO || videoMediaType) {
     tag.ad_types.push(VIDEO);
   }

--- a/test/spec/modules/adpod_spec.js
+++ b/test/spec/modules/adpod_spec.js
@@ -839,6 +839,84 @@ describe('adpod.js', function () {
 
       expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('tier7_test_15s');
       expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('12.00_value_15s');
+    });
+
+    it('should fall back to cpm when prioritzeDeals is true if bid falls below minDealTier', function() {
+      config.setConfig({
+        adpod: {
+          deferCaching: true,
+          brandCategoryExclusion: true,
+          prioritizeDeals: true,
+          dealTier: {
+            'appnexus': {
+              'prefix': 'tier',
+              'minDealTier': 10
+            }
+          }
+        }
+      });
+
+      let bidResponse1 = {
+        adId: 'adId01277',
+        auctionId: 'no_defer_123',
+        mediaType: 'video',
+        bidderCode: 'appnexus',
+        cpm: 5,
+        pbMg: '5.00',
+        adserverTargeting: {
+          hb_pb: '5.00'
+        },
+        meta: {
+          adServerCatId: 'test'
+        },
+        video: {
+          context: ADPOD,
+          durationSeconds: 15,
+          durationBucket: 15,
+          dealTier: 7
+        }
+      };
+
+      let bidResponse2 = {
+        adId: 'adId46547',
+        auctionId: 'no_defer_123',
+        mediaType: 'video',
+        bidderCode: 'appnexus',
+        cpm: 12,
+        pbMg: '12.00',
+        adserverTargeting: {
+          hb_pb: '12.00'
+        },
+        meta: {
+          adServerCatId: 'value'
+        },
+        video: {
+          context: ADPOD,
+          durationSeconds: 15,
+          durationBucket: 15,
+          dealTier: 14
+        }
+      };
+
+      let bidderRequest = {
+        adUnitCode: 'adpod_1',
+        auctionId: 'no_defer_123',
+        mediaTypes: {
+          video: {
+            context: ADPOD,
+            playerSize: [[300, 300]],
+            adPodDurationSec: 300,
+            durationRangeSec: [15, 30, 45],
+            requireExactDuration: false
+          }
+        },
+      };
+
+      callPrebidCacheHook(callbackFn, auctionInstance, bidResponse1, afterBidAddedSpy, bidderRequest);
+      callPrebidCacheHook(callbackFn, auctionInstance, bidResponse2, afterBidAddedSpy, bidderRequest);
+
+      expect(auctionBids[0].adserverTargeting.hb_pb_cat_dur).to.equal('5.00_test_15s');
+      expect(auctionBids[1].adserverTargeting.hb_pb_cat_dur).to.equal('tier14_value_15s');
     })
   });
 


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
This change modifies the logic in how the adpod keys are created for bids when using dealTier settings.  Previously if a bid falls below the dealTier, then the key still used the dealTier values.  

Now if a bid falls below, we'll switch back to the CPM for the corresponding key and value.  A bid has to clear the bidder's minDealTier in order to use the dealTier in the adpod keys.